### PR TITLE
feat!: Media field improvements

### DIFF
--- a/src/editor/api.ts
+++ b/src/editor/api.ts
@@ -841,6 +841,12 @@ export interface MediaOptions {
    * request.
    */
   provider?: RemoteMediaProviders | string;
+  /**
+   * Set if it is set as the default used for all media uploads.
+   *
+   * Local media upload is the default upload unless otherwise designated.
+   */
+  isDefault?: boolean;
 }
 
 /**

--- a/src/editor/field/mediaList.ts
+++ b/src/editor/field/mediaList.ts
@@ -30,11 +30,6 @@ const DEFAULT_FIELD_CONFIG: MediaFieldConfig = {
   key: '',
   label: 'Media',
 };
-const DEFAULT_REMOTE_FIELD_CONFIG: MediaFieldConfig = {
-  type: 'remoteMedia',
-  key: '',
-  label: 'Media',
-};
 
 export interface MediaListFieldConfig extends FieldConfig {
   /**
@@ -49,6 +44,11 @@ export interface MediaListFieldConfig extends FieldConfig {
    * Field definition for the media field.
    */
   fieldConfig?: MediaFieldConfig;
+  /**
+   * Override the default media upload provider to determine if the upload
+   * should be remote.
+   */
+  remote?: boolean;
 }
 
 export interface MediaListFieldComponent extends FieldComponent {
@@ -106,7 +106,6 @@ export class MediaListField
   globalConfig: LiveEditorGlobalConfig;
   protected items: Array<MediaListItemComponent> | null;
   protected MediaListItemCls: MediaListItemConstructor;
-  protected MediaListItemDefaultConfig: MediaFieldConfig;
   usingAutoFields: boolean;
 
   constructor(
@@ -121,7 +120,6 @@ export class MediaListField
     this.items = null;
     this.usingAutoFields = false;
     this.MediaListItemCls = MediaListFieldItem;
-    this.MediaListItemDefaultConfig = DEFAULT_FIELD_CONFIG;
     this.sortableUi.listeners.add('sort', this.handleSort.bind(this));
     this.droppableUi.validTypes = this.config.fieldConfig?.accepted || [
       ...VALID_IMAGE_MIME_TYPES,
@@ -158,7 +156,13 @@ export class MediaListField
     if (this.items === null) {
       this.items = [];
       const fieldConfig =
-        this.config.fieldConfig || this.MediaListItemDefaultConfig;
+        this.config.fieldConfig ||
+        Object.assign(
+          {
+            remote: this.config.remote,
+          },
+          DEFAULT_FIELD_CONFIG
+        );
 
       // Add list items for each of the values in the list already.
       for (const value of this.originalValue || []) {
@@ -187,7 +191,14 @@ export class MediaListField
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleAddItem(evt: Event, editor: SelectiveEditor, data: DeepObject) {
     const items = this.ensureItems(editor);
-    const fieldConfig = this.config.fieldConfig || DEFAULT_FIELD_CONFIG;
+    const fieldConfig =
+      this.config.fieldConfig ||
+      Object.assign(
+        {
+          remote: this.config.remote,
+        },
+        DEFAULT_FIELD_CONFIG
+      );
     const newField = this.types.fields.newFromKey(
       fieldConfig.type,
       this.types,
@@ -571,17 +582,5 @@ class MediaListFieldItem
     >
       <i class="material-icons icon icon--delete">remove_circle</i>
     </div>`;
-  }
-}
-
-export class RemoteMediaListField extends MediaListField {
-  constructor(
-    types: Types,
-    config: MediaListFieldConfig,
-    globalConfig: LiveEditorGlobalConfig,
-    fieldType = 'remoteMediaList'
-  ) {
-    super(types, config, globalConfig, fieldType);
-    this.MediaListItemDefaultConfig = DEFAULT_REMOTE_FIELD_CONFIG;
   }
 }

--- a/src/example/field/exampleField.ts
+++ b/src/example/field/exampleField.ts
@@ -15,6 +15,7 @@ import {DeepClean} from '../../utility/deepClean';
 import {LiveEditorGlobalConfig} from '../../editor/editor';
 import {createPriorityKeySort} from '../../utility/prioritySort';
 import yaml from 'js-yaml';
+import {DataType} from '../../../../selective-edit/dist/src/utility/dataType';
 
 export interface ExampleFieldUrl {
   label: string;
@@ -46,11 +47,13 @@ export class ExampleFieldField extends Field {
     // Copy the config to show the original before the field makes changes.
     this.originalFieldConfig = Object.assign({}, config.field);
 
-    this.originalFieldConfig.validation = [
-      ...((this.originalFieldConfig.validation as Array<RuleConfig>) || []),
-    ];
-    if (!this.originalFieldConfig.validation.length) {
-      this.originalFieldConfig.validation = undefined;
+    if (DataType.isArray(this.originalFieldConfig.validation)) {
+      this.originalFieldConfig.validation = [
+        ...((this.originalFieldConfig.validation as Array<RuleConfig>) || []),
+      ];
+      if (!this.originalFieldConfig.validation.length) {
+        this.originalFieldConfig.validation = undefined;
+      }
     }
 
     this.cleaner = new DeepClean({

--- a/src/example/field/exampleField.ts
+++ b/src/example/field/exampleField.ts
@@ -54,6 +54,40 @@ export class ExampleFieldField extends Field {
       if (!this.originalFieldConfig.validation.length) {
         this.originalFieldConfig.validation = undefined;
       }
+    } else if (DataType.isObject(this.originalFieldConfig.validation)) {
+      const keys = Object.keys(
+        this.originalFieldConfig.validation as Record<string, Array<RuleConfig>>
+      );
+      for (const key of keys) {
+        (
+          this.originalFieldConfig.validation as Record<
+            string,
+            Array<RuleConfig>
+          >
+        )[key] = [
+          ...(((
+            this.originalFieldConfig.validation as Record<
+              string,
+              Array<RuleConfig>
+            >
+          )[key] as Array<RuleConfig>) || []),
+        ];
+        if (
+          !(
+            this.originalFieldConfig.validation as Record<
+              string,
+              Array<RuleConfig>
+            >
+          )[key].length
+        ) {
+          (
+            this.originalFieldConfig.validation as Record<
+              string,
+              Array<RuleConfig> | undefined
+            >
+          )[key] = undefined;
+        }
+      }
     }
 
     this.cleaner = new DeepClean({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export {DeepClean} from './utility/deepClean';
 export {DeepWalk} from './utility/deepWalk';
+export {FeatureManager} from './utility/featureManager';
+export {IncludeExcludeFilter} from './utility/filter';
 export {LiveEditor} from './editor/editor';

--- a/src/server/editor.ts
+++ b/src/server/editor.ts
@@ -23,8 +23,7 @@ import {
 import {LiveEditor, LiveEditorSelectiveEditorConfig} from '../editor/editor';
 import {LiveEditorApiComponent, PingStatus} from '../editor/api';
 import {LocalServerApi, ServerApiComponent} from './api';
-import {MediaField, RemoteMediaField} from '../editor/field/media';
-import {MediaListField, RemoteMediaListField} from '../editor/field/mediaList';
+
 import {AsideField} from '../editor/field/aside';
 import {EditorState} from '../editor/state';
 import {ExampleFieldField} from '../example/field/exampleField';
@@ -33,6 +32,8 @@ import {GithubApi} from './gh/githubApi';
 import {HtmlField} from '../editor/field/html';
 import {LocalStatus} from './local';
 import {MarkdownField} from '../editor/field/markdown';
+import {MediaField} from '../editor/field/media';
+import {MediaListField} from '../editor/field/mediaList';
 import {RemoteMediaConstructor} from '../remoteMedia';
 import StackdriverErrorReporter from 'stackdriver-errors-js';
 import {rafTimeout} from '../utility/rafTimeout';
@@ -114,8 +115,6 @@ const fieldTypes = {
   mediaList: MediaListField as unknown as FieldConstructor,
   number: NumberField as unknown as FieldConstructor,
   radio: RadioField as unknown as FieldConstructor,
-  remoteMedia: RemoteMediaField as unknown as FieldConstructor,
-  remoteMediaList: RemoteMediaListField as unknown as FieldConstructor,
   text: TextField as unknown as FieldConstructor,
   textarea: TextareaField as unknown as FieldConstructor,
   time: TimeField as unknown as FieldConstructor,


### PR DESCRIPTION
Updated the media fields, removed the `remoteMedia` and `remoteMediaList`. Instead the media field will use the media settings from the editor config to figure out the default media options to use. Individual fields can now override the global default for remote media by providing a `remote` config for the field.