### PR TITLE
fix: fix an issue when the media preview is not a string

### DIFF
--- a/src/ts/editor/field/media.ts
+++ b/src/ts/editor/field/media.ts
@@ -1,4 +1,5 @@
 import {
+  DataType,
   DeepObject,
   DroppableMixin,
   DroppableUiComponent,
@@ -306,7 +307,7 @@ export class MediaField
       return value.url;
     }
 
-    if (value && value.path && typeof value.path === 'string') {
+    if (value && value.path && DataType.isString(value.path)) {
       if (
         value.path.startsWith('http:') ||
         value.path.startsWith('https:') ||

--- a/src/ts/editor/field/media.ts
+++ b/src/ts/editor/field/media.ts
@@ -306,7 +306,7 @@ export class MediaField
       return value.url;
     }
 
-    if (value && value.path) {
+    if (value && value.path && typeof value.path === 'string') {
       if (
         value.path.startsWith('http:') ||
         value.path.startsWith('https:') ||


### PR DESCRIPTION
Not sure if this is the right fix but it guards against the crash.

Fixes this error:

```
Uncaught TypeError: e.path.startsWith is not a function
    at u.get previewUrl [as previewUrl] (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:50873)
    at u.templatePreviewMedia (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:50979)
    at l.templateCollapsed (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:51306)
    at l.template (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:51260)
    at app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:51228
    at app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:35794
    at f.commit (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:36134)
    at o.update (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:36309)
    at f.__commitTemplateResult (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:36161)
    at f.commit (app.min.js?fingerprint=2f9b7d317dbae006e7bc3da2a168810f:formatted:36137)
```

Value of `e.path` here is:

```
_data: "/assets/assets.yaml?howSearchWorks3_small.url"
_type: "pod.yaml"
```