### PR TITLE
fix: saving a file updates the url after save

### DIFF
--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -324,7 +324,7 @@ export class EditorState extends ListenersMixin(Base) {
         this.file = data;
         delete this.promises[promiseKey];
 
-        // Update the file url is it is not defined.
+        // Update the file url as it is not defined.
         this.ensureFileUrl();
 
         // Loading is complete, remove the loading file information.
@@ -595,7 +595,7 @@ export class EditorState extends ListenersMixin(Base) {
         this.file = data;
         delete this.promises[promiseKey];
 
-        // Update the file url is it is not defined.
+        // Update the file url as it is not defined.
         this.ensureFileUrl();
 
         // Reload the workspace from the api.

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -324,7 +324,7 @@ export class EditorState extends ListenersMixin(Base) {
         this.file = data;
         delete this.promises[promiseKey];
 
-        // Update the file url as it is not defined.
+        // Update the file url as it may not be not defined.
         this.ensureFileUrl();
 
         // Loading is complete, remove the loading file information.
@@ -595,7 +595,7 @@ export class EditorState extends ListenersMixin(Base) {
         this.file = data;
         delete this.promises[promiseKey];
 
-        // Update the file url as it is not defined.
+        // Update the file url as it may not be not defined.
         this.ensureFileUrl();
 
         // Reload the workspace from the api.


### PR DESCRIPTION
When loading or saving a file, the url may not be known. Fix so that after both instances it attempts to load the url from the preview server.

fixes: #82