### PR TITLE
fix: reload iframe after file save

### DIFF
--- a/src/ts/editor/events.ts
+++ b/src/ts/editor/events.ts
@@ -11,6 +11,18 @@ export const EVENT_FILE_LOAD = 'live.file.load';
 export const EVENT_FILE_LOAD_COMPLETE = 'live.file.load.complete';
 
 /**
+ * Custom event name for saveing a file in the editor.
+ *
+ * Expects a {@link FileData} as the event details.
+ */
+export const EVENT_FILE_SAVE = 'live.file.save';
+
+/**
+ * Custom event name for finished a file save in the editor.
+ */
+export const EVENT_FILE_SAVE_COMPLETE = 'live.file.save.complete';
+
+/**
  * Custom event name for adding a notification.
  *
  * Expects a {@link EditorNotification} as the event details.

--- a/src/ts/editor/parts/preview/frame.ts
+++ b/src/ts/editor/parts/preview/frame.ts
@@ -1,7 +1,9 @@
 import {BasePart, Part} from '..';
 import {TemplateResult, classMap, html, styleMap} from '@blinkk/selective-edit';
+
 import {DataStorage} from '../../../utility/dataStorage';
 import {DeviceData} from '../../api';
+import {EVENT_FILE_SAVE_COMPLETE} from '../../events';
 import {EditorState} from '../../state';
 import {LiveEditor} from '../../editor';
 
@@ -40,6 +42,18 @@ export class PreviewFramePart extends BasePart implements Part {
   constructor(config: PreviewFrameConfig) {
     super();
     this.config = config;
+
+    // Watch for a save file event and reload the iframe.
+    document.addEventListener(EVENT_FILE_SAVE_COMPLETE, () => {
+      // Find and reload the iframe if it is visible.
+      const iframe = document.querySelector('.le__part__preview__frame iframe');
+      if (iframe) {
+        // Needs to be manually set in JS since the html src does not change the
+        // value and will not trigger a refresh like it will in JS.
+        (iframe as HTMLIFrameElement).src =
+          this.config.state.file?.url || (iframe as HTMLIFrameElement).src;
+      }
+    });
   }
 
   classesForPart(): Record<string, boolean> {

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -16,7 +16,11 @@ import {
   WorkspaceData,
   catchError,
 } from './api';
-import {EVENT_FILE_LOAD_COMPLETE, EVENT_RENDER} from './events';
+import {
+  EVENT_FILE_LOAD_COMPLETE,
+  EVENT_FILE_SAVE_COMPLETE,
+  EVENT_RENDER,
+} from './events';
 import {AmagakiState} from '../projectType/amagaki/amagakiState';
 import {Base} from '@blinkk/selective-edit/dist/mixins';
 import {FeatureManager} from '../utility/featureManager';
@@ -589,6 +593,7 @@ export class EditorState extends ListenersMixin(Base) {
     if (this.inProgress(promiseKey)) {
       return;
     }
+
     this.promises[promiseKey] = this.api
       .saveFile(file, isRawEdit)
       .then(data => {
@@ -607,6 +612,7 @@ export class EditorState extends ListenersMixin(Base) {
         }
         this.triggerListener(promiseKey);
         document.dispatchEvent(new CustomEvent(EVENT_FILE_LOAD_COMPLETE));
+        document.dispatchEvent(new CustomEvent(EVENT_FILE_SAVE_COMPLETE));
         this.render();
       })
       .catch(error => catchError(error, callbackError));


### PR DESCRIPTION
Add an event for after the file is saved. Listen for the event and refresh the iframe if it exists.

fixes #87