### PR TITLE
chore: improve slim toolbar and preview background

### DIFF
--- a/src/sass/_scheme.sass
+++ b/src/sass/_scheme.sass
@@ -31,6 +31,9 @@
 
   --color-elevation-hover: 0 0 0 0 #cbd4db, 0 1px 8px 0 rgba(21, 7, 38, 0.088)
 
+  --color-preview-background: #ffffff
+  --color-preview-background-image: linear-gradient(rgba(220,220,220, .3) 1px, transparent 1px), linear-gradient(90deg, rgba(220, 220, 220, .3) 1px, transparent 1px)
+
   @media (prefers-color-scheme: dark)
     --color-background: #121212
     --color-on-background: #f2f2f2

--- a/src/sass/parts/preview/_frame.sass
+++ b/src/sass/parts/preview/_frame.sass
@@ -1,7 +1,9 @@
 .le__part__preview__container
   align-items: stretch
-  background-color: var(--color-background)
   color: var(--color-on-background)
+  background-color: var(--color-preview-background-color)
+  background-image: var(--color-preview-background-image)
+  background-size: 20px 20px, 20px 20px
   display: flex
   flex-flow: column
   flex-grow: 1

--- a/src/sass/ui/_actions.sass
+++ b/src/sass/ui/_actions.sass
@@ -7,6 +7,7 @@
 
   &--slim
     margin: 0 $le-space-xsmall
+    position: absolute
 
 .le__actions__action
   background: var(--list-item-background-color)

--- a/src/sass/ui/_list.sass
+++ b/src/sass/ui/_list.sass
@@ -116,7 +116,6 @@
     position: relative
 
     & > *
-      position: relative
       z-index: 1
 
   &.le__clickable::after
@@ -136,6 +135,9 @@
 
     .le__actions
       opacity: 1
+
+    .le__actions--slim
+      position: relative
 
   &--primary.le__clickable,
   &--primary.le__clickable:hover


### PR DESCRIPTION
This should correctly fix what I was trying to do earlier -- prevent the icons from taking up horizontal space until hovered.

![image](https://user-images.githubusercontent.com/646525/125137850-5b00fa00-e0c2-11eb-88df-115fe81cc8e7.png)
