### PR TITLE
fix: only truncate file names on hover for file list

### DIFF
--- a/src/sass/ui/_actions.sass
+++ b/src/sass/ui/_actions.sass
@@ -2,6 +2,7 @@
   align-items: center
   display: flex
   flex-flow: row
+  flex-wrap: nowrap
   column-gap: $le-space-xxsmall
   margin: 0 $le-space-medium
 

--- a/src/sass/ui/_list.sass
+++ b/src/sass/ui/_list.sass
@@ -11,6 +11,11 @@
   &--indent
     padding-left: $le-space-medium
 
+  &--hide-actions
+    .le__list__item
+      .le__actions
+        display: none
+
   > .le__list
     padding-left: $le-space-medium
 
@@ -109,9 +114,6 @@
   &--emphasis
     font-weight: 700
 
-  .le__actions
-    opacity: 0
-
   &.le__clickable
     position: relative
 
@@ -134,8 +136,9 @@
     --list-item-background-color: var(--color-tertiary)
     color: var(--color-on-tertiary)
 
-    .le__actions
-      opacity: 1
+    .le__list--hide-actions &
+      .le__actions
+        display: flex
 
   &--primary.le__clickable,
   &--primary.le__clickable:hover
@@ -156,6 +159,7 @@
 
 .le__list__item__label
   flex-grow: 1
+  flex-shrink: 1
   line-height: $le-line-height-paragraph
   margin: $le-space-small
   overflow: hidden

--- a/src/ts/editor/parts/menu/site.ts
+++ b/src/ts/editor/parts/menu/site.ts
@@ -595,7 +595,7 @@ class DirectoryStructure {
       return html``;
     }
 
-    return html`<div class="le__list">
+    return html`<div class="le__list le__list--hide-actions">
       <div
         class="le__list__item le__list__item--primary le__clickable"
         @click=${(evt: Event) => this.eventHandlers.fileNew(evt, this.root)}

--- a/src/ts/example/exampleApi.ts
+++ b/src/ts/example/exampleApi.ts
@@ -1162,7 +1162,7 @@ const currentFileset: Array<FileData> = [
     path: '/content/pages/index.yaml',
   },
   {
-    path: '/content/pages/index.png',
+    path: '/content/pages/really-long-page-name-that-gets-truncated-in-ui.yaml',
   },
   {
     path: '/content/pages/about.md',


### PR DESCRIPTION
Previously the actions were always there, but not shown and file names were truncated even when they didn't need to be.

![image](https://user-images.githubusercontent.com/107076/125141648-dec2e280-e0d2-11eb-8c81-732f05e7f724.png)

![image](https://user-images.githubusercontent.com/107076/125141674-eedac200-e0d2-11eb-91dc-9ce794423540.png)
