### PR TITLE
fix: promise callback queue and example api for preview server

### DIFF
--- a/src/ts/editor/parts/preview/toolbar.ts
+++ b/src/ts/editor/parts/preview/toolbar.ts
@@ -50,7 +50,7 @@ export class PreviewToolbarPart extends BasePart implements Part {
     this.config.state.getDevices((devices: Array<DeviceData>) => {
       // Check for matching device labels to stored device info.
       const storedDevice = this.config.storage.getItem(STORAGE_DEVICE_KEY);
-      if (storedDevice) {
+      if (storedDevice && devices) {
         for (const device of devices) {
           if (device.label === storedDevice) {
             this.device = device;

--- a/src/ts/example/exampleApi.ts
+++ b/src/ts/example/exampleApi.ts
@@ -1544,6 +1544,11 @@ export class ExampleApi implements LiveEditorApiComponent {
       simulateNetwork(resolve, {
         title: 'Example project',
         publish: publish,
+        preview: {
+          // Use the current server for the preview for the example since it is
+          // referencing a static file for the example preview.
+          baseUrl: 'http://localhost:8888/',
+        },
         users: [
           {
             name: 'Example User',
@@ -1555,7 +1560,7 @@ export class ExampleApi implements LiveEditorApiComponent {
             isGroup: true,
           },
         ],
-      });
+      } as ProjectData);
     });
   }
 


### PR DESCRIPTION
Adding promise callback handling to bind to the existing promise if there is already a promise in the works.

This prevents the callback from being lost when there is already a request in process.

Also fixed the example api to use a 'preview server' for the `/content/pages/index.yaml` in the example to simulate the process of using the api to load the preview server settings to determine the serving url of a page.