### PR TITLE
fix: auto field guessing for specific project types

### DIFF
--- a/src/ts/editor/editor.ts
+++ b/src/ts/editor/editor.ts
@@ -1,10 +1,5 @@
 import {DataStorage, LocalDataStorage} from '../utility/dataStorage';
-import {
-  EVENT_PROJECT_TYPE_UPDATE,
-  EVENT_RENDER,
-  EVENT_RENDER_COMPLETE,
-  EVENT_SAVE,
-} from './events';
+import {EVENT_RENDER, EVENT_RENDER_COMPLETE, EVENT_SAVE} from './events';
 import {
   EditorConfig,
   GlobalConfig,
@@ -100,7 +95,6 @@ export class LiveEditor {
   isPendingRender?: boolean;
   isRendering?: boolean;
   parts: LiveEditorParts;
-  projectType?: ProjectTypeComponent;
   state: EditorState;
   storage: DataStorage;
 
@@ -251,31 +245,7 @@ export class LiveEditor {
   }
 
   updateProjectType(projectType: ProjectTypeComponent) {
-    this.projectType = projectType;
-    this.config.selectiveConfig = this.config.selectiveConfig || {};
-
-    // Update selective fields available.
-    this.config.selectiveConfig.fieldTypes =
-      this.config.selectiveConfig.fieldTypes || {};
-
-    for (const [key, value] of Object.entries(
-      this.projectType.fieldTypes || {}
-    )) {
-      this.config.selectiveConfig.fieldTypes[key] = value;
-    }
-
-    // Update selective validation rules available.
-    this.config.selectiveConfig.ruleTypes =
-      this.config.selectiveConfig.ruleTypes || {};
-
-    for (const [key, value] of Object.entries(
-      this.projectType.ruleTypes || {}
-    )) {
-      this.config.selectiveConfig.ruleTypes[key] = value;
-    }
-
-    // Event to allow existing selective editors to reset.
-    document.dispatchEvent(new CustomEvent(EVENT_PROJECT_TYPE_UPDATE));
+    this.state.setProjectType(projectType);
   }
 }
 

--- a/src/ts/editor/events.ts
+++ b/src/ts/editor/events.ts
@@ -44,11 +44,6 @@ export const EVENT_NOTIFICATION_READ = 'live.notification.read';
 export const EVENT_NOTIFICATION_SHOW = 'live.notification.show';
 
 /**
- * Custom event name for after updating the project type for the editor.
- */
-export const EVENT_PROJECT_TYPE_UPDATE = 'live.projectType.update';
-
-/**
  * Custom event name for triggering a render.
  */
 export const EVENT_RENDER = 'live.render';

--- a/src/ts/editor/parts/content/section.ts
+++ b/src/ts/editor/parts/content/section.ts
@@ -6,9 +6,13 @@ import {
   classMap,
   html,
 } from '@blinkk/selective-edit';
+import {EditorState, StatePromiseKeys} from '../../../editor/state';
+import {
+  ProjectTypeComponent,
+  updateSelectiveForProjectType,
+} from '../../../projectType/projectType';
+
 import {DataStorage} from '../../../utility/dataStorage';
-import {EVENT_PROJECT_TYPE_UPDATE} from '../../events';
-import {EditorState} from '../../../editor/state';
 import {LiveEditor} from '../../editor';
 import {LiveEditorAutoFields} from '../../autoFields';
 
@@ -47,6 +51,15 @@ export class ContentSectionPart extends BasePart implements Part {
     // Override the autofields class.
     this.selective.types.globals.AutoFieldsCls = LiveEditorAutoFields;
 
+    // When the project type is updated the selective editor changes.
+    this.config.state.addListener(
+      StatePromiseKeys.SetProjectType,
+      (projectType: ProjectTypeComponent) => {
+        updateSelectiveForProjectType(projectType, this.selective);
+        this.render();
+      }
+    );
+
     if (this.isVisible === undefined) {
       const currentSection = this.config.storage.getItem(
         STORAGE_CONTENT_SECTION
@@ -57,16 +70,6 @@ export class ContentSectionPart extends BasePart implements Part {
         this.isVisible = this.section === currentSection;
       }
     }
-
-    // When the project type is updated the field types change.
-    // Update the field types on the selective editor which
-    // also reloads the fields on the selective editor.
-    document.addEventListener(EVENT_PROJECT_TYPE_UPDATE, () => {
-      this.selective.addFieldTypes(
-        this.config.selectiveConfig.fieldTypes || {}
-      );
-      this.render();
-    });
 
     // Show a message when there are pending changes and navigating.
     window.addEventListener('beforeunload', (evt: BeforeUnloadEvent) => {
@@ -98,6 +101,7 @@ export class ContentSectionPart extends BasePart implements Part {
     return classes;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleAction(evt: Event) {
     console.log('missing action handler.');
   }

--- a/src/ts/editor/parts/menu/site.ts
+++ b/src/ts/editor/parts/menu/site.ts
@@ -63,6 +63,7 @@ export class SitePart extends MenuSectionPart {
       const modal = new FormDialogModal({
         title: 'Copy file',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
       modal.templateModal = this.templateFileCopy.bind(this);
       modal.actions.push({
@@ -116,6 +117,7 @@ export class SitePart extends MenuSectionPart {
       const modal = new FormDialogModal({
         title: 'Delete file',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
       modal.templateModal = this.templateFileDelete.bind(this);
       modal.actions.push({
@@ -161,6 +163,7 @@ export class SitePart extends MenuSectionPart {
       const modal = new FormDialogModal({
         title: 'New file',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
       modal.templateModal = this.templateFileNew.bind(this);
       modal.actions.push({

--- a/src/ts/editor/parts/menu/workspaces.ts
+++ b/src/ts/editor/parts/menu/workspaces.ts
@@ -101,6 +101,7 @@ export class WorkspacesPart extends MenuSectionPart {
       const modal = new FormDialogModal({
         title: 'New workspace',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
       modal.templateModal = this.templateNewWorkspace.bind(this);
       modal.actions.push({

--- a/src/ts/editor/parts/overview.ts
+++ b/src/ts/editor/parts/overview.ts
@@ -55,6 +55,7 @@ export class OverviewPart extends BasePart implements Part {
       const modal = new FormDialogModal({
         title: editor.config.labels?.publishModalTitle || 'Publish',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
       modal.templateModal = this.templatePublishWorkspace.bind(this);
       modal.actions.push({

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -29,6 +29,7 @@ import {FeatureManager} from '../utility/featureManager';
 import {GrowState} from '../projectType/grow/growState';
 import {ListenersMixin} from '../mixin/listeners';
 import {interpolatePreviewBaseUrl} from './preview';
+import {ProjectTypeComponent} from '../projectType/projectType';
 
 const REGEX_START_SLASH = /^\//i;
 const STORAGE_SCHEME = 'live.scheme';
@@ -75,6 +76,10 @@ export class EditorState extends ListenersMixin(Base) {
    * Preview server settings.
    */
   previewConfig?: PreviewSettings | null;
+  /**
+   * Project type in use.
+   */
+  projectType?: ProjectTypeComponent;
   /**
    * Project information.
    */
@@ -653,6 +658,7 @@ export class EditorState extends ListenersMixin(Base) {
    */
   setScheme(scheme: Schemes) {
     this.scheme = scheme;
+    this.triggerListener(StatePromiseKeys.SetScheme, this.scheme);
 
     if (
       (scheme === Schemes.Light && !this.prefersDarkScheme) ||
@@ -666,6 +672,11 @@ export class EditorState extends ListenersMixin(Base) {
       // Store when using a scheme that is not the preferred.
       this.storage.setItem(STORAGE_SCHEME, scheme);
     }
+  }
+
+  setProjectType(projectType: ProjectTypeComponent) {
+    this.projectType = projectType;
+    this.triggerListener(StatePromiseKeys.SetProjectType, this.projectType);
   }
 }
 
@@ -719,4 +730,6 @@ export enum StatePromiseKeys {
   LoadWorkspace = 'LoadWorkspace',
   Publish = 'Publish',
   SaveFile = 'SaveFile',
+  SetScheme = 'SetScheme',
+  SetProjectType = 'SetProjectType',
 }

--- a/src/ts/projectType/amagaki/amagakiAutoFields.ts
+++ b/src/ts/projectType/amagaki/amagakiAutoFields.ts
@@ -1,0 +1,38 @@
+import {ConstructorConfig} from '../generic/field/constructor';
+import {DataType} from '@blinkk/selective-edit';
+import {LiveEditorAutoFields} from '../../editor/autoFields';
+
+export class AmagakiAutoFields extends LiveEditorAutoFields {
+  protected deepGuessObject(
+    data: Record<string, any>,
+    keyBase?: Array<string>
+  ) {
+    keyBase = keyBase || [];
+    const key = keyBase.join('.');
+
+    // Check for constrctor field.
+    if (data._type && DataType.isString(data._type)) {
+      let type = '';
+      if (data._type === 'pod.doc') {
+        type = 'document';
+      } else if (data._type === 'pod.staticFile') {
+        type = 'static';
+      } else if (data._type === 'pod.string') {
+        type = 'string';
+      } else if (data._type === 'pod.yaml') {
+        type = 'yaml';
+      }
+      if (type !== '') {
+        return [
+          {
+            key: key,
+            type: type,
+            label: this.guessLabel(key),
+          } as ConstructorConfig,
+        ];
+      }
+    }
+
+    return super.deepGuessObject(data, keyBase);
+  }
+}

--- a/src/ts/projectType/amagaki/amagakiProjectType.ts
+++ b/src/ts/projectType/amagaki/amagakiProjectType.ts
@@ -1,3 +1,4 @@
+import {AmagakiAutoFields} from './amagakiAutoFields';
 import {AmagakiDocumentField} from './field/document';
 import {AmagakiPartialsField} from './field/partials';
 import {AmagakiStaticField} from './field/static';
@@ -8,14 +9,15 @@ import {ProjectTypeComponent} from '../projectType';
 
 export class AmagakiProjectType implements ProjectTypeComponent {
   type = 'amagaki';
+  AutoFieldsCls = AmagakiAutoFields;
 
   get fieldTypes(): Record<string, FieldConstructor> {
     return {
-      document: (AmagakiDocumentField as unknown) as FieldConstructor,
-      partials: (AmagakiPartialsField as unknown) as FieldConstructor,
-      string: (AmagakiStringField as unknown) as FieldConstructor,
-      static: (AmagakiStaticField as unknown) as FieldConstructor,
-      yaml: (AmagakiYamlField as unknown) as FieldConstructor,
+      document: AmagakiDocumentField as unknown as FieldConstructor,
+      partials: AmagakiPartialsField as unknown as FieldConstructor,
+      string: AmagakiStringField as unknown as FieldConstructor,
+      static: AmagakiStaticField as unknown as FieldConstructor,
+      yaml: AmagakiYamlField as unknown as FieldConstructor,
     };
   }
 }

--- a/src/ts/projectType/amagaki/field/document.ts
+++ b/src/ts/projectType/amagaki/field/document.ts
@@ -35,7 +35,7 @@ export class AmagakiDocumentField extends AutocompleteConstructorField {
     super(types, config, globalConfig, fieldType);
     this.config = config;
     this.globalConfig = globalConfig;
-    this.type = 'pod.document';
+    this.type = 'pod.doc';
     this.filter = new IncludeExcludeFilter({});
 
     this.initFilter();

--- a/src/ts/projectType/amagaki/field/static.ts
+++ b/src/ts/projectType/amagaki/field/static.ts
@@ -28,7 +28,7 @@ export class AmagakiStaticField extends AutocompleteConstructorField {
     types: Types,
     config: AmagakiStaticConfig,
     globalConfig: LiveEditorGlobalConfig,
-    fieldType = 'document'
+    fieldType = 'static'
   ) {
     super(types, config, globalConfig, fieldType);
     this.config = config;

--- a/src/ts/projectType/generic/field/partials.ts
+++ b/src/ts/projectType/generic/field/partials.ts
@@ -18,6 +18,7 @@ import {
 } from '@blinkk/selective-edit/dist/selective/field/list';
 import {LiveEditor, LiveEditorGlobalConfig} from '../../../editor/editor';
 import {EVENT_UNLOCK} from '@blinkk/selective-edit/dist/selective/events';
+import {EditorState} from '../../../editor/state';
 import {PartialData} from '../../../editor/api';
 import {findPreviewValue} from '@blinkk/selective-edit/dist/utility/preview';
 import merge from 'lodash.merge';
@@ -46,6 +47,7 @@ export interface GenericPartialsFieldConfig extends FieldConfig {
    * Required message when adding a partial.
    */
   partialRequireLabel?: string;
+  state: EditorState;
 }
 
 export interface GenericPartialsFieldComponent {
@@ -183,6 +185,7 @@ export class GenericPartialsField
       const modal = new FormDialogModal({
         title: this.config.addLabel || 'Add partial',
         selectiveConfig: selectiveConfig,
+        state: this.config.state,
       });
 
       // Show an error when there are no partial configs for the editor.

--- a/src/ts/projectType/grow/growAutoFields.ts
+++ b/src/ts/projectType/grow/growAutoFields.ts
@@ -1,0 +1,38 @@
+import {ConstructorConfig} from '../generic/field/constructor';
+import {DataType} from '@blinkk/selective-edit';
+import {LiveEditorAutoFields} from '../../editor/autoFields';
+
+export class GrowAutoFields extends LiveEditorAutoFields {
+  protected deepGuessObject(
+    data: Record<string, any>,
+    keyBase?: Array<string>
+  ) {
+    keyBase = keyBase || [];
+    const key = keyBase.join('.');
+
+    // Check for constrctor field.
+    if (data._type && DataType.isString(data._type)) {
+      let type = '';
+      if (data._type === 'g.doc') {
+        type = 'document';
+      } else if (data._type === 'g.static') {
+        type = 'static';
+      } else if (data._type === 'g.string') {
+        type = 'string';
+      } else if (data._type === 'g.yaml') {
+        type = 'yaml';
+      }
+      if (type !== '') {
+        return [
+          {
+            key: key,
+            type: type,
+            label: this.guessLabel(key),
+          } as ConstructorConfig,
+        ];
+      }
+    }
+
+    return super.deepGuessObject(data, keyBase);
+  }
+}

--- a/src/ts/projectType/grow/growProjectType.ts
+++ b/src/ts/projectType/grow/growProjectType.ts
@@ -1,4 +1,5 @@
 import {FieldConstructor} from '@blinkk/selective-edit';
+import {GrowAutoFields} from './growAutoFields';
 import {GrowDocumentField} from './field/document';
 import {GrowPartialsField} from './field/partials';
 import {GrowStaticField} from './field/static';
@@ -7,6 +8,7 @@ import {ProjectTypeComponent} from '../projectType';
 
 export class GrowProjectType implements ProjectTypeComponent {
   type = 'grow';
+  AutoFieldsCls = GrowAutoFields;
 
   get fieldTypes(): Record<string, FieldConstructor> {
     return {

--- a/src/ts/projectType/projectType.ts
+++ b/src/ts/projectType/projectType.ts
@@ -1,6 +1,16 @@
-import {FieldConstructor, RuleConstructor} from '@blinkk/selective-edit';
+import {
+  FieldConstructor,
+  RuleConstructor,
+  SelectiveEditor,
+} from '@blinkk/selective-edit';
+
+import {AutoFieldsConstructor} from '@blinkk/selective-edit/dist/selective/autoFields';
 
 export interface ProjectTypeComponent {
+  /**
+   * Class to use for guessing fields for the project type.
+   */
+  AutoFieldsCls?: AutoFieldsConstructor;
   /**
    * Type identifier for the projectType component.
    *
@@ -15,4 +25,17 @@ export interface ProjectTypeComponent {
    * Validation rule types unique to the projectType component.
    */
   ruleTypes?: Record<string, RuleConstructor>;
+}
+
+export function updateSelectiveForProjectType(
+  projectType: ProjectTypeComponent,
+  selective: SelectiveEditor
+) {
+  selective.addFieldTypes(projectType.fieldTypes || {});
+  selective.addRuleTypes(projectType.ruleTypes || {});
+
+  // Check for project type specific autofields class.
+  if (projectType && projectType.AutoFieldsCls) {
+    selective.types.globals.AutoFieldsCls = projectType.AutoFieldsCls;
+  }
 }


### PR DESCRIPTION
Allows the project type to define custom auto guessing classes for use in guessing unknown fields.

Also moves the projectType variable from the Editor to the State.

fixes #95