### PR TITLE
fix: missing preview config handled outside default handler

### DIFF
--- a/src/ts/editor/parts/dashboard.ts
+++ b/src/ts/editor/parts/dashboard.ts
@@ -191,15 +191,13 @@ export class DashboardPart extends BasePart implements Part {
     } else {
       subParts.push(html`<p>Select a file from the menu to begin editing.</p>`);
     }
-    return html`<div class=${classMap(this.classesForPart())}>
-      ${subParts}
-    </div>`;
+    return html`${subParts}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   templateRecentWorkspaces(editor: LiveEditor): TemplateResult {
     const subParts: Array<TemplateResult> = [];
-    if (this.recentWorkspaces.length) {
+    if (this.recentWorkspaces.length > 1) {
       subParts.push(html`<div class="le__part__dashboard__recent">
         <h2>Recent Workspaces</h2>
         <div class="le__grid le__grid--3-2 le__grid--col-4">
@@ -239,9 +237,7 @@ export class DashboardPart extends BasePart implements Part {
         </div>
       </div>`);
     }
-    return html`<div class=${classMap(this.classesForPart())}>
-      ${subParts}
-    </div>`;
+    return html`${subParts}`;
   }
 
   updateRecentFile(path: string) {

--- a/src/ts/editor/parts/preview.ts
+++ b/src/ts/editor/parts/preview.ts
@@ -103,7 +103,9 @@ export class PreviewPart extends BasePart implements Part {
   templatePreviewNotConfigured(editor: LiveEditor): TemplateResult {
     // TODO: Link to the documentation on setting up a preview server.
     return html`<div class="le__part__preview__message">
-      <div>No preview server configured.</div>
+      <div>
+        No preview server configured or unable to load preview configuration.
+      </div>
     </div>`;
   }
 }

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -433,7 +433,14 @@ export class EditorState extends ListenersMixin(Base) {
       this.promises[promiseKey] = this.api
         .getPreviewConfig(project.preview as EditorPreviewSettings, workspace)
         .then(handlePreviewSettings)
-        .catch(() => {
+        .catch((err: Error) => {
+          if (callbackError) {
+            callbackError({
+              message: err.toString(),
+              details: err,
+            });
+          }
+
           console.error('Unable to load preview server config');
           this.previewConfig = null;
           this.render();

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -47,6 +47,10 @@ export class EditorState extends ListenersMixin(Base) {
    */
   api: LiveEditorApiComponent;
   /**
+   * Keep track of backlogged callbacks.
+   */
+  protected callbacks: Record<string, Set<(...value: any) => void>>;
+  /**
    * Array of devices supported for previews.
    */
   devices?: Array<DeviceData>;
@@ -93,10 +97,6 @@ export class EditorState extends ListenersMixin(Base) {
    * multiple times.
    */
   protected promises: Record<string, Promise<any> | boolean>;
-  /**
-   * Keep track of backlogged callbacks.
-   */
-  protected callbacks: Record<string, Set<(...value: any) => void>>;
   /**
    * Whether the user prefers dark mode.
    */
@@ -433,7 +433,11 @@ export class EditorState extends ListenersMixin(Base) {
       this.promises[promiseKey] = this.api
         .getPreviewConfig(project.preview as EditorPreviewSettings, workspace)
         .then(handlePreviewSettings)
-        .catch(error => catchError(error, callbackError));
+        .catch(() => {
+          console.error('Unable to load preview server config');
+          this.previewConfig = null;
+          this.render();
+        });
     };
 
     const handleProject = (project: ProjectData) => {

--- a/src/ts/server/api.ts
+++ b/src/ts/server/api.ts
@@ -161,10 +161,10 @@ export class ServerApi implements LiveEditorApiComponent, ServerApiComponent {
     settings: EditorPreviewSettings,
     workspace: WorkspaceData
   ): Promise<PreviewSettings> {
+    // TODO: Make the credentials optional with setting?
+    // TODO: Need to send credentials for IAP with fetch, how to do with bent?
     // return await getJSON(interpolatePreviewConfigUrl(settings, workspace));
 
-    // TODO: Need to send credentials for IAP with fetch, how to do with bent?
-    // TODO: Make the credentials optional with setting?
     const codes = new Set();
     codes.add(200);
 


### PR DESCRIPTION
Update the preview to not prompt with the error if it cannot load the preview server config. Updated the message instead to show the message in the preview pane.

Fixes #106