### PR TITLE
fix: reload files and file on workspace change

### DIFF
--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -597,6 +597,17 @@ export class EditorState extends ListenersMixin(Base) {
         // Reload the workspace from the api.
         // Refreshes the publish status.
         this.workspace = this.getWorkspace();
+
+        // Reload the files if loaded.
+        if (this.files) {
+          this.getFiles();
+        }
+
+        // Reload the open file after the workspace switch.
+        if (this.file?.file) {
+          this.getFile(this.file.file);
+        }
+
         this.handleDataAndCleanup(promiseKey, data);
         this.render();
       })


### PR DESCRIPTION
When changing the workspace, reload the files and the open file.

fixes: #111