### PR TITLE
fix: border color between panels of UI

### DIFF
--- a/src/sass/editor.sass
+++ b/src/sass/editor.sass
@@ -2,8 +2,9 @@
 @import 'scheme'
 
 .le
-  background: var(--color-background)
-  color: var(--color-on-background)
+  // Uses tertiary background to provide the 'gap' color for panels.
+  background-color: var(--color-tertiary)
+  color: var(--color-on-tertiary)
   display: grid
   font-family: var(--font-family-default)
   font-size: $le-font-size
@@ -30,6 +31,10 @@
   .material-icons
     font-size: $le-font-size-icon
     vertical-align: middle
+
+.le__panel
+  background: var(--color-background)
+  color: var(--color-on-background)
 
 .le__structure__content
   display: flex

--- a/src/sass/parts/_dashboard.sass
+++ b/src/sass/parts/_dashboard.sass
@@ -1,5 +1,6 @@
 .le__part__dashboard
-  margin: $le-space-medium
+  flex-grow: 1
+  padding: $le-space-medium
 
 .le__part__dashboard__loading
   align-items: center

--- a/src/ts/editor/parts/content.ts
+++ b/src/ts/editor/parts/content.ts
@@ -99,6 +99,7 @@ export class ContentPart extends BasePart implements Part {
 
   classesForPart(): Record<string, boolean> {
     return {
+      le__panel: true,
       le__part__content: true,
     };
   }

--- a/src/ts/editor/parts/dashboard.ts
+++ b/src/ts/editor/parts/dashboard.ts
@@ -80,6 +80,7 @@ export class DashboardPart extends BasePart implements Part {
 
   classesForPart(): Record<string, boolean> {
     return {
+      le__panel: true,
       le__part__dashboard: true,
       'le__part__dashboard--loading': this.config.state.inProgress(
         StatePromiseKeys.GetFile

--- a/src/ts/editor/parts/menu.ts
+++ b/src/ts/editor/parts/menu.ts
@@ -75,6 +75,7 @@ export class MenuPart extends BasePart implements Part {
 
   classesForPart(): Record<string, boolean> {
     return {
+      le__panel: true,
       le__part__menu: true,
     };
   }

--- a/src/ts/editor/parts/overview.ts
+++ b/src/ts/editor/parts/overview.ts
@@ -37,6 +37,7 @@ export class OverviewPart extends BasePart implements Part {
 
   classesForPart(): Record<string, boolean> {
     return {
+      le__panel: true,
       le__part__overview: true,
     };
   }

--- a/src/ts/editor/parts/preview.ts
+++ b/src/ts/editor/parts/preview.ts
@@ -47,6 +47,7 @@ export class PreviewPart extends BasePart implements Part {
 
   classesForPart(): Record<string, boolean> {
     return {
+      le__panel: true,
       le__part__preview: true,
       'le__part__preview--device_mode':
         (this.parts.toolbar.isDeviceMode || false) &&


### PR DESCRIPTION
Use the tertiary color as the background color to provide the gap coloring for panels.

Part of #143