### PR TITLE
feat: editor history as a stand alone part of the state

### DIFF
--- a/src/sass/parts/_onboarding.sass
+++ b/src/sass/parts/_onboarding.sass
@@ -53,6 +53,11 @@
   padding: $le-space-medium
   width: 100%
 
+  img
+    max-height: $le-space-xlarge
+    max-width: $le-space-xlarge
+    margin-bottom: $le-space-small
+
 .le__part__onboarding__loading
   align-items: center
   display: flex

--- a/src/ts/editor/api.ts
+++ b/src/ts/editor/api.ts
@@ -522,6 +522,10 @@ export interface PartialEditorConfig {
  */
 export interface ProjectData {
   /**
+   * Url for an avatar to use when showing a project.
+   */
+  avatarUrl?: string;
+  /**
    * Project title
    */
   title: string;

--- a/src/ts/editor/api.ts
+++ b/src/ts/editor/api.ts
@@ -1121,6 +1121,7 @@ export type RemoteMediaOptions = GoogleMediaOptions;
  * GitHub service installations information.
  */
 export interface GitHubInstallationInfo {
+  avatarUrl?: string;
   id: number;
   org: string;
   url: string;
@@ -1130,10 +1131,11 @@ export interface GitHubInstallationInfo {
  * GitHub service organization installation information.
  */
 export interface GitHubOrgInstallationInfo {
+  avatarUrl?: string;
   description: string;
-  updatedAt?: string;
   org: string;
   repo: string;
+  updatedAt?: string;
   url: string;
 }
 

--- a/src/ts/editor/recent.ts
+++ b/src/ts/editor/recent.ts
@@ -1,0 +1,282 @@
+import {DataStorage} from '../utility/dataStorage';
+import {ProjectSource} from './api';
+
+const STORAGE_RECENT_PROJECTS = 'live.history.recent.projects';
+const STORAGE_RECENT_PROJECT_PREFIX = 'live.history.';
+
+export interface EditorHistoryConfig {
+  storage: DataStorage;
+}
+
+export interface ProjectHistoryConfig {
+  id: string;
+  storage: DataStorage;
+}
+
+/**
+ * Track historical events in the editor.
+ *
+ * Uses a project identifier to store the history in the storage.
+ *
+ * Example identifiers: `local`, `gh/blinkk/project`.
+ *
+ * Usage:
+ *
+ * ```
+ * const editorHistory = new EditorHistory({
+ *   storage: storage,
+ * });
+ * const projectHistory = editorHistory.getProject('local');
+ * projectHistory.recentWorkspaces;
+ * ```
+ *
+ * The history is also used to store history of the general access
+ * of projects.
+ *
+ * ```
+ * const recentProjects = editorHistory.recentProjects;
+ * ```
+ */
+export class EditorHistory {
+  config: EditorHistoryConfig;
+
+  constructor(config: EditorHistoryConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Adds a project data to the history of recent projects.
+   *
+   * @param project Project information to add to the history.
+   * @returns Updated recent project history.
+   */
+  addRecentProject(project: RecentProjectData): Array<RecentProjectData> {
+    const updatedRecentProjects = updateRecentProjects(
+      this.recentProjects,
+      project
+    );
+    this.config.storage.setItemArray(
+      STORAGE_RECENT_PROJECTS,
+      updatedRecentProjects
+    );
+    return updatedRecentProjects;
+  }
+
+  /**
+   * Retrieve the project specific history data.
+   */
+  getProject(projectId: string): ProjectHistory {
+    return new ProjectHistory({
+      id: projectId,
+      storage: this.config.storage,
+    });
+  }
+
+  /**
+   * Retrieve the recent projects.
+   */
+  get recentProjects(): Array<RecentProjectData> {
+    return this.config.storage.getItemArray(STORAGE_RECENT_PROJECTS);
+  }
+}
+
+export class ProjectHistory {
+  config: ProjectHistoryConfig;
+  data: ProjectHistoryData;
+
+  constructor(config: ProjectHistoryConfig) {
+    this.config = config;
+
+    this.data = this.config.storage.getItemRecord(
+      `${STORAGE_RECENT_PROJECT_PREFIX}${this.config.id}`
+    );
+  }
+
+  /**
+   * Adds file data to the history of the project.
+   *
+   * @param workspace Workspace name the file belongs to.
+   * @param file File information to add to the history.
+   * @returns Updated recent file history.
+   */
+  addRecentFile(
+    workspace: string,
+    file: RecentFileData
+  ): Array<RecentFileData> {
+    this.data.recentFiles = this.data.recentFiles ?? {};
+    this.data.recentFiles[workspace] = this.data.recentFiles[workspace] ?? [];
+    this.data.recentFiles[workspace] = updateRecentFiles(
+      this.data.recentFiles[workspace],
+      file
+    );
+    this.save();
+    return this.data.recentFiles[workspace];
+  }
+
+  /**
+   * Adds workspace to the history of the project.
+   *
+   * @param workspace Workspace information to add to the history.
+   * @returns Updated recent file history.
+   */
+  addRecentWorkspace(
+    workspace: RecentWorkspaceData
+  ): Array<RecentWorkspaceData> {
+    this.data.recentWorkspaces = this.data.recentWorkspaces ?? [];
+    this.data.recentWorkspaces = updateRecentWorkspaces(
+      this.data.recentWorkspaces,
+      workspace
+    );
+    this.save();
+    return this.data.recentWorkspaces;
+  }
+
+  getRecentFiles(workspace: string): Array<RecentFileData> {
+    this.data.recentFiles = this.data.recentFiles ?? {};
+    this.data.recentFiles[workspace] = this.data.recentFiles[workspace] ?? [];
+    return this.data.recentFiles[workspace];
+  }
+
+  getRecentWorkspaces(): Array<RecentWorkspaceData> {
+    this.data.recentWorkspaces = this.data.recentWorkspaces ?? [];
+    return this.data.recentWorkspaces;
+  }
+
+  save() {
+    this.config.storage.setItemRecord(
+      `${STORAGE_RECENT_PROJECT_PREFIX}${this.config.id}`,
+      this.data
+    );
+  }
+}
+
+export interface ProjectHistoryData {
+  recentFiles?: Record<string, Array<RecentFileData>>;
+  recentWorkspaces?: Array<RecentWorkspaceData>;
+}
+
+export interface RecentProjectData {
+  /**
+   * Project identifier.
+   *
+   * ex: `local`, `blinkk/project`
+   */
+  identifier: string;
+  /**
+   * Source of the project.
+   */
+  source?: ProjectSource | string;
+  /**
+   * Label for displaying the project to the user.
+   */
+  label: string;
+  /**
+   * Avatar url for the project.
+   */
+  avatarUrl?: string;
+  /**
+   * Timestamp of last date visited
+   */
+  lastVisited: string;
+}
+
+export interface RecentFileData {
+  /**
+   * Path for the file.
+   */
+  path: string;
+  /**
+   * Timestamp of last date visited
+   */
+  lastVisited: string;
+}
+
+export interface RecentWorkspaceData {
+  /**
+   * Name of the workspace.
+   */
+  name: string;
+  /**
+   * Timestamp of last date visited
+   */
+  lastVisited: string;
+}
+
+function updateRecentFiles(
+  list: Array<RecentFileData>,
+  value: RecentFileData,
+  maxCount = 10
+): Array<RecentFileData> {
+  let index: undefined | number = undefined;
+
+  // Search for matching item in the list.
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i];
+    if (item.path === value.path) {
+      index = i;
+      break;
+    }
+  }
+
+  return updateRecentList(list, value, index, maxCount);
+}
+
+function updateRecentProjects(
+  list: Array<RecentProjectData>,
+  value: RecentProjectData,
+  maxCount = 10
+): Array<RecentProjectData> {
+  let index: undefined | number = undefined;
+
+  // Search for matching item in the list.
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i];
+    if (item.source === value.source && item.identifier === value.identifier) {
+      index = i;
+      break;
+    }
+  }
+
+  return updateRecentList(list, value, index, maxCount);
+}
+
+function updateRecentWorkspaces(
+  list: Array<RecentWorkspaceData>,
+  value: RecentWorkspaceData,
+  maxCount = 10
+): Array<RecentWorkspaceData> {
+  let index: undefined | number = undefined;
+
+  // Search for matching item in the list.
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i];
+    if (item.name === value.name) {
+      index = i;
+      break;
+    }
+  }
+
+  return updateRecentList(list, value, index, maxCount);
+}
+
+function updateRecentList<T>(
+  list: Array<T>,
+  value: T,
+  index?: number,
+  maxCount = 10
+): Array<T> {
+  if (index !== undefined) {
+    // Already in recent, shift to the beginning of the list.
+    if (index > 0) {
+      list = [value, ...list.slice(0, index), ...list.slice(index + 1)];
+    }
+  } else {
+    // Add newest to the beginning of the list.
+    list.unshift(value);
+
+    // Trim old values.
+    list = list.slice(0, maxCount - 1) || [];
+  }
+
+  return list;
+}

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -655,6 +655,7 @@ export class EditorState extends ListenersMixin(Base) {
 
         // Add to recent project history.
         this.history.addRecentProject({
+          avatarUrl: this.project.avatarUrl,
           identifier: this.project.source?.identifier || 'unknown',
           source: this.project.source?.source,
           label: this.project.source?.label || this.project.title,

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -31,6 +31,7 @@ import {
 
 import {AmagakiState} from '../projectType/amagaki/amagakiState';
 import {Base} from '@blinkk/selective-edit/dist/mixins';
+import {EditorHistory} from './recent';
 import {FeatureManager} from '../utility/featureManager';
 import {GrowState} from '../projectType/grow/growState';
 import {ListenersMixin} from '../mixin/listeners';
@@ -79,6 +80,10 @@ export class EditorState extends ListenersMixin(Base) {
    * Value is null when the file is not found.
    */
   file?: EditorFileData | null;
+  /**
+   * Editor history.
+   */
+  history: EditorHistory;
   /**
    * Path being actively loaded.
    *
@@ -156,6 +161,9 @@ export class EditorState extends ListenersMixin(Base) {
     this.errorCallbacks = {};
     this.successCallbacks = {};
     this.storage = new LocalDataStorage();
+    this.history = new EditorHistory({
+      storage: this.storage,
+    });
 
     // Features are on by default.
     this.features = new FeatureManager({
@@ -479,6 +487,26 @@ export class EditorState extends ListenersMixin(Base) {
         // Update document title.
         this.updateTitle();
 
+        // Add the file to the project history.
+        if (this.projectId) {
+          const projectHistory = this.history.getProject(this.projectId);
+          const fileHistory = {
+            path: file.path,
+            lastVisited: new Date().toISOString(),
+          };
+          if (this.workspace) {
+            projectHistory.addRecentFile(this.workspace.name, fileHistory);
+          } else {
+            this.getWorkspace(() => {
+              if (!this.workspace) {
+                console.error('Unable to add file history, missing workspace.');
+                return;
+              }
+              projectHistory.addRecentFile(this.workspace.name, fileHistory);
+            });
+          }
+        }
+
         this.handleDataAndCleanup(promiseKey, this.file);
 
         document.dispatchEvent(new CustomEvent(EVENT_FILE_LOAD_COMPLETE));
@@ -625,6 +653,14 @@ export class EditorState extends ListenersMixin(Base) {
         // Update document title.
         this.updateTitle();
 
+        // Add to recent project history.
+        this.history.addRecentProject({
+          identifier: this.project.source?.identifier || 'unknown',
+          source: this.project.source?.source,
+          label: this.project.source?.label || this.project.title,
+          lastVisited: new Date().toISOString(),
+        });
+
         this.handleDataAndCleanup(promiseKey, this.project);
       })
       .catch((error: ApiError) =>
@@ -634,7 +670,7 @@ export class EditorState extends ListenersMixin(Base) {
   }
 
   getWorkspace(
-    callback?: (project: WorkspaceData) => void,
+    callback?: (workspace: WorkspaceData) => void,
     callbackError?: (error: ApiError) => void
   ): WorkspaceData | undefined {
     const promiseKey = StatePromiseKeys.GetWorkspace;
@@ -649,6 +685,15 @@ export class EditorState extends ListenersMixin(Base) {
 
         // Update document title.
         this.updateTitle();
+
+        // Add the workspace to the project history.
+        if (this.projectId) {
+          const projectHistory = this.history.getProject(this.projectId);
+          projectHistory.addRecentWorkspace({
+            name: this.workspace.name,
+            lastVisited: new Date().toISOString(),
+          });
+        }
 
         this.handleDataAndCleanup(promiseKey, data);
       })
@@ -767,6 +812,13 @@ export class EditorState extends ListenersMixin(Base) {
       this.getFile(this.pendingFile);
       this.pendingFile = undefined;
     }
+  }
+
+  get projectId(): string | undefined {
+    if (this.project?.source?.source && this.project?.source?.identifier) {
+      return `${this.project.source.source}/${this.project.source.identifier}`;
+    }
+    return undefined;
   }
 
   publish(

--- a/src/ts/editor/ui/parts/onboarding/github.ts
+++ b/src/ts/editor/ui/parts/onboarding/github.ts
@@ -323,12 +323,19 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
                 role="button"
                 aria-pressed="false"
               >
-                <a
-                  href="${BASE_URL}${org.org}/"
-                  @click=${preventNormalLinks}
-                  tabindex="-1"
-                  >${org.org}</a
-                >
+                ${org.avatarUrl
+                  ? html`<div>
+                      <img src=${org.avatarUrl} alt=${org.org} />
+                    </div>`
+                  : ''}
+                <div>
+                  <a
+                    href="${BASE_URL}${org.org}/"
+                    @click=${preventNormalLinks}
+                    tabindex="-1"
+                    >${org.org}</a
+                  >
+                </div>
               </div>`;
             }
           )}
@@ -344,13 +351,12 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
   }
 
   templateRecentProjects(): TemplateResult {
-    const recent: DashboardRecent =
-      this.config.editor.storage.getItemRecord(STORAGE_RECENT) ?? {};
+    let recentProjects = this.config.state.history.recentProjects;
 
     // Filter down all the recent to just ones that belong to the current
     // organization.
-    const recentProjects = (recent.projects ?? []).filter(project =>
-      project.startsWith(`${this.api.organization}/`)
+    recentProjects = recentProjects.filter(project =>
+      project.identifier.startsWith(`${this.api.organization}/`)
     );
 
     if (!recentProjects.length) {
@@ -367,8 +373,8 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
         >
           ${repeat(
             recentProjects,
-            projectId => projectId,
-            projectId => {
+            project => project.identifier,
+            project => {
               return html`<div
                 class=${classMap({
                   le__grid__item: true,
@@ -378,7 +384,7 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
                   le__clickable: true,
                 })}
                 @click=${() => {
-                  const repository = projectId.replace(
+                  const repository = project.identifier.replace(
                     `${this.api.organization}/`,
                     ''
                   );
@@ -403,12 +409,17 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
                 role="button"
                 aria-pressed="false"
               >
-                <a
-                  href="${BASE_URL}${projectId}/"
-                  @click=${preventNormalLinks}
-                  tabindex="-1"
-                  >${projectId}</a
-                >
+                <div>
+                  <a
+                    href="${BASE_URL}${project.identifier}/"
+                    @click=${preventNormalLinks}
+                    tabindex="-1"
+                    >${project.identifier}</a
+                  >
+                </div>
+                <div class="le__part__onboarding__github__time">
+                  Visited ${this.timeAgo.format(new Date(project.lastVisited))}
+                </div>
               </div>`;
             }
           )}


### PR DESCRIPTION
Pulling the logic for a the editor history out of the dashboard UI and into a separate class that is part of the state.