### PR TITLE
fix: UX messaging around the preview status.

### DIFF
--- a/src/sass/parts/_preview.sass
+++ b/src/sass/parts/_preview.sass
@@ -8,5 +8,8 @@
   padding: $le-space-medium
   line-height: $le-line-height-paragraph
 
+  h3
+    margin-top: 0
+
 @import './preview/frame'
 @import './preview/toolbar'

--- a/src/sass/ui/_button.sass
+++ b/src/sass/ui/_button.sass
@@ -86,3 +86,6 @@
 
 .le__button
   +button
+
+  &--outline
+    +button-outline

--- a/src/ts/editor/api.ts
+++ b/src/ts/editor/api.ts
@@ -377,6 +377,10 @@ export interface DeviceData {
    */
   height?: number;
   /**
+   * Is the device the default for the device view?
+   */
+  isDefault?: boolean;
+  /**
    * Label for the device.
    */
   label: string;

--- a/src/ts/editor/ui/parts/preview/toolbar.ts
+++ b/src/ts/editor/ui/parts/preview/toolbar.ts
@@ -57,12 +57,24 @@ export class PreviewToolbarPart extends BasePart implements UiPartComponent {
           if (device.label === storedDevice) {
             this.device = device;
             this.render();
-            break;
+            return;
           }
         }
-      } else if (devices.length >= 1) {
-        // Default to the first device in the list if none selected.
+      }
+
+      // Check for a default device in config.
+      for (const device of devices) {
+        if (device.isDefault) {
+          this.device = device;
+          this.render();
+          return;
+        }
+      }
+
+      // Default to the first device in the list if none selected.
+      if (!this.device && devices.length >= 1) {
         this.device = devices[0];
+        this.render();
       }
     });
   }

--- a/src/ts/editor/ui/parts/preview/toolbar.ts
+++ b/src/ts/editor/ui/parts/preview/toolbar.ts
@@ -32,8 +32,10 @@ export class PreviewToolbarPart extends BasePart implements UiPartComponent {
     super();
     this.config = config;
     this.isDeviceMode = this.config.storage.getItemBoolean(
-      STORAGE_DEVICE_MODE_KEY
+      STORAGE_DEVICE_MODE_KEY,
+      true
     );
+
     this.isExpanded = this.config.storage.getItemBoolean(STORAGE_EXPANDED_KEY);
     this.isRotated = this.config.storage.getItemBoolean(
       STORAGE_DEVICE_ROTATED_KEY
@@ -58,6 +60,9 @@ export class PreviewToolbarPart extends BasePart implements UiPartComponent {
             break;
           }
         }
+      } else if (devices.length >= 1) {
+        // Default to the first device in the list if none selected.
+        this.device = devices[0];
       }
     });
   }


### PR DESCRIPTION
Adds the ability to open the preview server's base url in a window and reloads the preview config either manually or after the 'login' window is closed to test if the request is able to proceed.

![image](https://user-images.githubusercontent.com/107076/128065485-a21a1fa7-20b3-4531-9134-131531db428b.png)

fixes #158