### PR TITLE
fix: Footer for the menu with light/dark mode toggle.

### DIFF
--- a/src/sass/parts/_menu.sass
+++ b/src/sass/parts/_menu.sass
@@ -1,7 +1,12 @@
+.le__part__menu
+  display: flex
+  flex-flow: column
+
 .le__part__menu__content
+  flex-grow: 1
+  flex-shrink: 1
+  height: 0
   overflow-x: auto
-  // TODO: Hacky way to scroll the contents of the menu.
-  max-height: calc(100vh - 46px)
 
 .le__part__menu__header
   align-items: center
@@ -33,3 +38,5 @@
 
 .le__part__menu__section__title
   padding: $le-space-medium 0
+
+@import "./menu/_footer"

--- a/src/sass/parts/_menu.sass
+++ b/src/sass/parts/_menu.sass
@@ -1,6 +1,7 @@
 .le__part__menu
   display: flex
   flex-flow: column
+  flex-grow: 1
 
 .le__part__menu__content
   flex-grow: 1

--- a/src/sass/parts/content/_footer.sass
+++ b/src/sass/parts/content/_footer.sass
@@ -15,7 +15,6 @@
     max-width: 28px
 
 .le__part__content__dev_tools
-  font-size: $le-font-size-small
   margin: $le-space-medium 0
 
 .le__part__content__dev_tools__icons

--- a/src/sass/parts/menu/_footer.sass
+++ b/src/sass/parts/menu/_footer.sass
@@ -1,0 +1,11 @@
+.le__part__menu__footer
+  align-items: center
+  border-top: $le-border-size-medium solid var(--color-tertiary)
+  display: flex
+  flex-flow: row
+  justify-content: space-between
+  min-height: $le-space-large
+
+.le__part__menu__footer__icons
+  padding-left: $le-space-small
+  padding-right: $le-space-small

--- a/src/sass/parts/menu/_footer.sass
+++ b/src/sass/parts/menu/_footer.sass
@@ -1,6 +1,7 @@
 .le__part__menu__footer
   align-items: center
-  border-top: $le-border-size-medium solid var(--color-tertiary)
+  background-color: var(--color-tertiary)
+  color: var(--color-on-tertiary)
   display: flex
   flex-flow: row
   justify-content: space-between
@@ -9,3 +10,6 @@
 .le__part__menu__footer__icons
   padding-left: $le-space-small
   padding-right: $le-space-small
+
+.le__part__menu__footer__label
+  margin: $le-space-medium 0

--- a/src/sass/parts/preview/_toolbar.sass
+++ b/src/sass/parts/preview/_toolbar.sass
@@ -34,13 +34,12 @@
   &--toggle
     border-bottom: $le-border-size-large solid transparent
 
-    &:hover:not(.le__part__preview__toolbar__icon--disabled),
+    &:hover:not(.le__actions__action--disabled),
     &.le__part__preview__toolbar__icon--selected
       border-bottom: $le-border-size-large solid var(--color-on-primary-light)
 
-  &--disabled
-    .material-icons
-      opacity: $le-opacity-disabled
+    &:hover.le__actions__action--disabled
+      border-bottom: $le-border-size-large solid transparent
 
 .le__part__preview__toolbar__label
   font-size: $le-font-size-small

--- a/src/sass/ui/_actions.sass
+++ b/src/sass/ui/_actions.sass
@@ -16,3 +16,10 @@
 
   &:hover
     border-bottom: $le-border-size-medium solid var(--color-on-action-background)
+
+  &--disabled
+    cursor: default
+
+    // Only opacity on children so that tooltip is not applied.
+    > *
+      opacity: $le-opacity-disabled

--- a/src/sass/ui/_button.sass
+++ b/src/sass/ui/_button.sass
@@ -33,6 +33,7 @@
   cursor: pointer
   font-family: var(--font-family-default)
   font-size: $le-font-size
+  font-weight: 500
   line-height: $le-font-size
   padding: $le-space-small
   transition: opacity $le-speed-xslow

--- a/src/sass/ui/_modal.sass
+++ b/src/sass/ui/_modal.sass
@@ -47,6 +47,8 @@
     width: 80vw
 
   .le__modal--docked &
+    display: flex
+    flex-flow: column
     flex-grow: 1
     min-width: 300px
     width: 30%

--- a/src/sass/ui/_tooltip.sass
+++ b/src/sass/ui/_tooltip.sass
@@ -11,6 +11,7 @@
     display: none
     font-family: var(--font-family-default)
     font-size: $le-font-size-small
+    font-weight: 500
     left: 100%
     margin-left: $le-space-small
     padding: $le-space-small

--- a/src/ts/editor/ui/parts/menu/footer.ts
+++ b/src/ts/editor/ui/parts/menu/footer.ts
@@ -1,0 +1,85 @@
+import {BasePart, UiPartComponent, UiPartConfig} from '..';
+import {EditorState, Schemes} from '../../../state';
+import {TemplateResult, classMap, html} from '@blinkk/selective-edit';
+import {UrlConfig, UrlLevel} from '../../../api';
+
+import {DataStorage} from '../../../../utility/dataStorage';
+
+const STORAGE_EXPANDED_KEY = 'live.content.isExpanded';
+
+export interface MenuFooterPartConfig extends UiPartConfig {
+  /**
+   * State class for working with editor state.
+   */
+  state: EditorState;
+  /**
+   * Storage class for working with settings.
+   */
+  storage: DataStorage;
+}
+
+export class MenuFooterPart extends BasePart implements UiPartComponent {
+  config: MenuFooterPartConfig;
+  isExpanded?: boolean;
+
+  constructor(config: MenuFooterPartConfig) {
+    super();
+    this.config = config;
+    this.isExpanded = this.config.storage.getItemBoolean(STORAGE_EXPANDED_KEY);
+  }
+
+  classesForPart(): Record<string, boolean> {
+    return {
+      le__part__menu__footer: true,
+    };
+  }
+
+  getIconForUrl(url: UrlConfig): string {
+    if (url.level === UrlLevel.Public) {
+      return 'public';
+    }
+    if (url.level === UrlLevel.Protected) {
+      return 'vpn_lock';
+    }
+    if (url.level === UrlLevel.Source) {
+      return 'source';
+    }
+    return 'lock';
+  }
+
+  template(): TemplateResult {
+    return html`<div class=${classMap(this.classesForPart())}>
+      <div class="le__part__menu__footer__icons">
+        ${this.templateActionScheme()}
+      </div>
+    </div>`;
+  }
+
+  templateActionScheme(): TemplateResult {
+    let currentMode = this.config.state.prefersDarkScheme
+      ? Schemes.Dark
+      : Schemes.Light;
+
+    if (this.config.state.scheme === Schemes.Dark) {
+      currentMode = Schemes.Dark;
+    } else if (this.config.state.scheme === Schemes.Light) {
+      currentMode = Schemes.Light;
+    }
+
+    const toggleMode =
+      currentMode === Schemes.Light ? Schemes.Dark : Schemes.Light;
+    const icon = currentMode === Schemes.Dark ? 'light_mode' : 'dark_mode';
+    const tip = `${toggleMode} mode`;
+
+    return html`<div
+      class="le__part__menu__action le__clickable le__tooltip--top-right"
+      @click=${() => {
+        this.config.state.setScheme(toggleMode);
+        this.render();
+      }}
+      data-tip=${tip}
+    >
+      <span class="material-icons">${icon}</span>
+    </div>`;
+  }
+}

--- a/src/ts/editor/ui/parts/menu/footer.ts
+++ b/src/ts/editor/ui/parts/menu/footer.ts
@@ -52,6 +52,9 @@ export class MenuFooterPart extends BasePart implements UiPartComponent {
       <div class="le__part__menu__footer__icons">
         ${this.templateActionScheme()}
       </div>
+      <!-- Spacing is based on text, not icons. -->
+      <!-- Need some text to use for spacing. -->
+      <div class="le__part__menu__footer__label">&nbsp;</div>
     </div>`;
   }
 

--- a/src/ts/editor/ui/parts/preview/toolbar.ts
+++ b/src/ts/editor/ui/parts/preview/toolbar.ts
@@ -202,7 +202,8 @@ export class PreviewToolbarPart extends BasePart implements UiPartComponent {
     return html`<div
       class=${classMap({
         le__part__preview__toolbar__icon: true,
-        'le__part__preview__toolbar__icon--disabled': blockRotate,
+        le__actions__action: true,
+        'le__actions__action--disabled': blockRotate,
         'le__part__preview__toolbar__icon--selected': this.isRotated || false,
         'le__part__preview__toolbar__icon--toggle': true,
         le__clickable: true,


### PR DESCRIPTION
Move the light/dark mode into a menu footer.

Cleanup some of the styling with actions and disabled states.