### PR TITLE
fix: Infinite loading when errors retrieving data

### DIFF
--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -117,7 +117,7 @@ export class EditorState extends ListenersMixin(Base) {
    *
    * Value is null when the project cannot be loaded.
    */
-  _project?: ProjectData | null;
+  project?: ProjectData | null;
   /**
    * Project types states.
    */
@@ -845,23 +845,20 @@ export class EditorState extends ListenersMixin(Base) {
    * Understands the null state when there is an error requesting the
    * project state and does not re-request the project info.
    */
-  get project(): ProjectData | undefined | null {
+  projectOrGetProject(): ProjectData | undefined | null {
     if (
-      this._project === undefined &&
+      this.project === undefined &&
       !this.inProgress(StatePromiseKeys.GetProject)
     ) {
       this.getProject();
     }
-    return this._project;
-  }
-
-  set project(project: ProjectData | undefined | null) {
-    this._project = project;
+    return this.project;
   }
 
   get projectId(): string | undefined {
-    if (this.project?.source?.source && this.project?.source?.identifier) {
-      return `${this.project.source.source}/${this.project.source.identifier}`;
+    const project = this.projectOrGetProject();
+    if (project?.source?.source && project?.source?.identifier) {
+      return `${project.source.source}/${project.source.identifier}`;
     }
     return undefined;
   }

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -117,7 +117,7 @@ export class EditorState extends ListenersMixin(Base) {
    *
    * Value is null when the project cannot be loaded.
    */
-  project?: ProjectData | null;
+  _project?: ProjectData | null;
   /**
    * Project types states.
    */
@@ -837,6 +837,26 @@ export class EditorState extends ListenersMixin(Base) {
       this.getFile(this.pendingFile);
       this.pendingFile = undefined;
     }
+  }
+
+  /**
+   * Lazy load of project data.
+   *
+   * Understands the null state when there is an error requesting the
+   * project state and does not re-request the project info.
+   */
+  get project(): ProjectData | undefined | null {
+    if (
+      this._project === undefined &&
+      !this.inProgress(StatePromiseKeys.GetProject)
+    ) {
+      this.getProject();
+    }
+    return this._project;
+  }
+
+  set project(project: ProjectData | undefined | null) {
+    this._project = project;
   }
 
   get projectId(): string | undefined {

--- a/src/ts/editor/state.ts
+++ b/src/ts/editor/state.ts
@@ -558,6 +558,7 @@ export class EditorState extends ListenersMixin(Base) {
             preventDefaultHandling: true,
           });
         } else {
+          this.file = null;
           this.handleErrorAndCleanup(promiseKey, error);
         }
       });

--- a/src/ts/editor/ui/parts/dashboard.ts
+++ b/src/ts/editor/ui/parts/dashboard.ts
@@ -110,10 +110,9 @@ export class DashboardPart extends BasePart implements UiPartComponent {
     const subParts: Array<TemplateResult> = [];
     let recentFiles: Array<RecentFileData> = [];
 
-    if (this.projectHistory && this.config.state.workspace) {
-      recentFiles = this.projectHistory.getRecentFiles(
-        this.config.state.workspace.name
-      );
+    const workspace = this.config.state.workspaceOrGetWorkspace();
+    if (this.projectHistory && workspace) {
+      recentFiles = this.projectHistory.getRecentFiles(workspace.name);
     }
 
     if (recentFiles.length) {
@@ -161,11 +160,12 @@ export class DashboardPart extends BasePart implements UiPartComponent {
     const subParts: Array<TemplateResult> = [];
     let recentWorkspaces: Array<RecentWorkspaceData> = [];
 
+    const workspace = this.config.state.workspaceOrGetWorkspace();
     if (
       // Local projects do not provide workspace support.
       this.config.state.project?.source?.source !== ProjectSource.Local &&
       this.projectHistory &&
-      this.config.state.workspace
+      workspace
     ) {
       recentWorkspaces = this.projectHistory.getRecentWorkspaces();
     }

--- a/src/ts/editor/ui/parts/dashboard.ts
+++ b/src/ts/editor/ui/parts/dashboard.ts
@@ -43,7 +43,9 @@ export class DashboardPart extends BasePart implements UiPartComponent {
     this.config = config;
     this.timeAgo = new TimeAgo('en-US');
 
-    if (!this.config.state.projectId) {
+    if (!this.config.state.project === null) {
+      console.log('Unable to show dashboard without project');
+    } else if (!this.config.state.projectId) {
       this.config.state.getProject(() => {
         this.projectHistory = this.config.state.history.getProject(
           this.config.state.projectId as string

--- a/src/ts/editor/ui/parts/dashboard.ts
+++ b/src/ts/editor/ui/parts/dashboard.ts
@@ -42,21 +42,6 @@ export class DashboardPart extends BasePart implements UiPartComponent {
     super();
     this.config = config;
     this.timeAgo = new TimeAgo('en-US');
-
-    if (!this.config.state.project === null) {
-      console.log('Unable to show dashboard without project');
-    } else if (!this.config.state.projectId) {
-      this.config.state.getProject(() => {
-        this.projectHistory = this.config.state.history.getProject(
-          this.config.state.projectId as string
-        );
-        this.render();
-      });
-    } else {
-      this.projectHistory = this.config.state.history.getProject(
-        this.config.state.projectId
-      );
-    }
   }
 
   classesForPart(): Record<string, boolean> {
@@ -70,6 +55,12 @@ export class DashboardPart extends BasePart implements UiPartComponent {
   }
 
   template(): TemplateResult {
+    if (!this.projectHistory && this.config.state.projectId) {
+      this.projectHistory = this.config.state.history.getProject(
+        this.config.state.projectId
+      );
+    }
+
     const subParts: Array<TemplateResult> = [];
 
     subParts.push(this.templateFileNotFound());

--- a/src/ts/editor/ui/parts/menu.ts
+++ b/src/ts/editor/ui/parts/menu.ts
@@ -112,10 +112,6 @@ export class MenuPart extends BasePart implements UiPartComponent {
     this.render();
   }
 
-  loadProject() {
-    this.config.state.getProject();
-  }
-
   /**
    * Open the menu when it is not docked.
    */

--- a/src/ts/editor/ui/parts/menu/site.ts
+++ b/src/ts/editor/ui/parts/menu/site.ts
@@ -235,7 +235,7 @@ export class SitePart extends MenuSectionPart {
   }
 
   templateContent(): TemplateResult {
-    const project = this.config.state.project;
+    const project = this.config.state.projectOrGetProject();
     const files = this.config.state.files;
 
     // Lazy load the files.

--- a/src/ts/editor/ui/parts/menu/site.ts
+++ b/src/ts/editor/ui/parts/menu/site.ts
@@ -234,17 +234,13 @@ export class SitePart extends MenuSectionPart {
     });
   }
 
-  loadProject() {
-    this.config.state.getProject();
-  }
-
   templateContent(): TemplateResult {
     const project = this.config.state.project;
     const files = this.config.state.files;
 
     // Lazy load the project.
-    if (!project) {
-      this.loadProject();
+    if (project === undefined) {
+      this.config.state.getProject();
     }
 
     // Lazy load the files.

--- a/src/ts/editor/ui/parts/menu/site.ts
+++ b/src/ts/editor/ui/parts/menu/site.ts
@@ -238,11 +238,6 @@ export class SitePart extends MenuSectionPart {
     const project = this.config.state.project;
     const files = this.config.state.files;
 
-    // Lazy load the project.
-    if (project === undefined) {
-      this.config.state.getProject();
-    }
-
     // Lazy load the files.
     if (files === undefined) {
       this.loadFiles();

--- a/src/ts/editor/ui/parts/menu/site.ts
+++ b/src/ts/editor/ui/parts/menu/site.ts
@@ -227,23 +227,11 @@ export class SitePart extends MenuSectionPart {
     ] as FormDialogModal;
   }
 
-  loadFiles() {
-    this.config.state.getFiles(() => {
-      this.fileStructure = undefined;
-      this.render();
-    });
-  }
-
   templateContent(): TemplateResult {
     const project = this.config.state.projectOrGetProject();
-    const files = this.config.state.files;
+    const files = this.config.state.filesOrGetFiles();
 
-    // Lazy load the files.
-    if (files === undefined) {
-      this.loadFiles();
-    }
-
-    if (!project || files === undefined) {
+    if (!project || !files) {
       return templateLoading({
         pad: true,
       });

--- a/src/ts/editor/ui/parts/menu/users.ts
+++ b/src/ts/editor/ui/parts/menu/users.ts
@@ -1,7 +1,7 @@
 import {MenuSectionPart, MenuSectionPartConfig} from './index';
-import {ProjectData, UserData} from '../../../api';
 import {TemplateResult, html} from '@blinkk/selective-edit';
 
+import {UserData} from '../../../api';
 import {repeat} from '@blinkk/selective-edit';
 import {templateLoading} from '../../../template';
 
@@ -23,21 +23,15 @@ export class UsersPart extends MenuSectionPart {
     return classes;
   }
 
-  loadProject() {
-    this.users = this.config.state.getProject((project: ProjectData) => {
-      // Default to array so it does not try to keep reloading the project data.
-      this.users = project.users || [];
-      this.render();
-    })?.users;
-  }
-
   templateContent(): TemplateResult {
-    // Lazy load the users information.
-    if (this.users === undefined) {
-      this.loadProject();
+    // Lazy load the project information.
+    if (this.config.state.project === undefined) {
+      this.config.state.getProject();
       return templateLoading({
         pad: true,
       });
+    } else if (this.users === undefined) {
+      this.users = this.config.state.project?.users ?? [];
     }
 
     if (!this.users.length) {

--- a/src/ts/editor/ui/parts/menu/users.ts
+++ b/src/ts/editor/ui/parts/menu/users.ts
@@ -25,8 +25,7 @@ export class UsersPart extends MenuSectionPart {
 
   templateContent(): TemplateResult {
     // Lazy load the project information.
-    if (this.config.state.project === undefined) {
-      this.config.state.getProject();
+    if (!this.config.state.project) {
       return templateLoading({
         pad: true,
       });

--- a/src/ts/editor/ui/parts/menu/users.ts
+++ b/src/ts/editor/ui/parts/menu/users.ts
@@ -25,7 +25,7 @@ export class UsersPart extends MenuSectionPart {
 
   templateContent(): TemplateResult {
     // Lazy load the project information.
-    if (!this.config.state.project) {
+    if (!this.config.state.projectOrGetProject()) {
       return templateLoading({
         pad: true,
       });

--- a/src/ts/editor/ui/parts/menu/workspaces.ts
+++ b/src/ts/editor/ui/parts/menu/workspaces.ts
@@ -175,21 +175,9 @@ export class WorkspacesPart extends MenuSectionPart {
     ] as FormDialogModal;
   }
 
-  loadWorkspace() {
-    this.config.state.getWorkspace();
-  }
-
-  loadWorkspaces() {
-    this.config.state.getWorkspaces();
-  }
-
   templateContent(): TemplateResult {
-    // Lazy load the workspaces information.
-    if (!this.config.state.workspaces) {
-      this.loadWorkspaces();
-    }
-
-    if (!this.config.state.workspaces) {
+    const workspaces = this.config.state.workspacesOrGetWorkspaces();
+    if (!workspaces) {
       return templateLoading({
         pad: true,
       });
@@ -201,7 +189,7 @@ export class WorkspacesPart extends MenuSectionPart {
       >
         ${this.templateCreateWorkspace()}
         ${repeat(
-          this.config.state.workspaces || [],
+          workspaces || [],
           workspace => workspace.name,
           workspace => html`<div
             class=${classMap(this.classesForWorkspace(workspace))}

--- a/src/ts/editor/ui/parts/menu/workspaces.ts
+++ b/src/ts/editor/ui/parts/menu/workspaces.ts
@@ -38,11 +38,12 @@ export class WorkspacesPart extends MenuSectionPart {
   }
 
   classesForWorkspace(workspace: WorkspaceData): Record<string, boolean> {
+    const currentWorkspace = this.config.state.workspaceOrGetWorkspace();
+
     return {
       le__clickable: true,
       le__list__item: true,
-      'le__list__item--selected':
-        this.config.state.workspace?.name === workspace.name,
+      'le__list__item--selected': currentWorkspace?.name === workspace.name,
     };
   }
 
@@ -183,11 +184,6 @@ export class WorkspacesPart extends MenuSectionPart {
   }
 
   templateContent(): TemplateResult {
-    // Lazy load the workspace information.
-    if (!this.config.state.workspace) {
-      this.loadWorkspace();
-    }
-
     // Lazy load the workspaces information.
     if (!this.config.state.workspaces) {
       this.loadWorkspaces();

--- a/src/ts/editor/ui/parts/onboarding/github.ts
+++ b/src/ts/editor/ui/parts/onboarding/github.ts
@@ -2,7 +2,6 @@ import {BasePart, UiPartComponent, UiPartConfig} from '..';
 import {
   GitHubInstallationInfo,
   GitHubOrgInstallationInfo,
-  ProjectData,
   UserData,
   WorkspaceData,
 } from '../../../api';
@@ -230,14 +229,6 @@ export class GitHubOnboardingPart extends BasePart implements UiPartComponent {
       .catch(() => {
         console.error('Unable to retrieve the list of repositories.');
       });
-  }
-
-  loadProject() {
-    this.users = this.config.state.getProject((project: ProjectData) => {
-      // Default to array so it does not try to keep reloading the project data.
-      this.users = project.users || [];
-      this.render();
-    })?.users;
   }
 
   template(): TemplateResult {

--- a/src/ts/editor/ui/parts/onboarding/local.ts
+++ b/src/ts/editor/ui/parts/onboarding/local.ts
@@ -36,14 +36,6 @@ export class LocalOnboardingPart extends BasePart implements UiPartComponent {
     };
   }
 
-  loadProject() {
-    this.users = this.config.state.getProject((project: ProjectData) => {
-      // Default to array so it does not try to keep reloading the project data.
-      this.users = project.users || [];
-      this.render();
-    })?.users;
-  }
-
   template(): TemplateResult {
     return html`<div class=${classMap(this.classesForPart())}>
       <div class="le__part__onboarding__local__title">

--- a/src/ts/editor/ui/parts/overview.ts
+++ b/src/ts/editor/ui/parts/overview.ts
@@ -117,8 +117,8 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     const workspace = this.config.state.workspace;
 
     // Lazy load the project.
-    if (!project) {
-      this.loadProject();
+    if (project === undefined) {
+      this.config.state.getProject();
     }
 
     // Lazy load the workspace.
@@ -158,10 +158,6 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     // Need to collect additional data, show the modal for the form.
     const modal = this.getOrCreateModalPublish(project.publish?.fields || []);
     modal.show();
-  }
-
-  loadProject() {
-    this.config.state.getProject();
   }
 
   loadWorkspace() {
@@ -239,7 +235,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
 
     // Lazy load the project.
     if (project === undefined) {
-      this.loadProject();
+      this.config.state.getProject();
     }
 
     const parts: Array<TemplateResult> = [];
@@ -277,8 +273,8 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     const workspace = this.config.state.workspace;
 
     // Lazy load the project.
-    if (!project) {
-      this.loadProject();
+    if (project === undefined) {
+      this.config.state.getProject();
     }
 
     // Lazy load the workspace.

--- a/src/ts/editor/ui/parts/overview.ts
+++ b/src/ts/editor/ui/parts/overview.ts
@@ -77,7 +77,8 @@ export class OverviewPart extends BasePart implements UiPartComponent {
           modal.startProcessing();
 
           const value = modal.selective.value;
-          const workspace = this.config.state.workspace;
+          const workspace = this.config.state.workspaceOrGetWorkspace();
+
           if (!workspace) {
             return;
           }
@@ -114,12 +115,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handlePublishClick(evt: Event) {
     const project = this.config.state.projectOrGetProject();
-    const workspace = this.config.state.workspace;
-
-    // Lazy load the workspace.
-    if (!workspace) {
-      this.loadWorkspace();
-    }
+    const workspace = this.config.state.workspaceOrGetWorkspace();
 
     if (!workspace || !project) {
       return;
@@ -155,15 +151,12 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     modal.show();
   }
 
-  loadWorkspace() {
-    this.config.state.getWorkspace();
-  }
-
   showPublishResult(result: PublishResult) {
     console.log('publish result', result);
 
     const actions: Array<NotificationAction> = [];
-    const currentWorkspace = this.config.state.workspace;
+    const currentWorkspace = this.config.state.workspaceOrGetWorkspace();
+
     let message = '';
 
     if ([PublishStatus.Complete].includes(result.status as PublishStatus)) {
@@ -259,12 +252,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
 
   templatePublish(): TemplateResult {
     const project = this.config.state.projectOrGetProject();
-    const workspace = this.config.state.workspace;
-
-    // Lazy load the workspace.
-    if (!workspace) {
-      this.loadWorkspace();
-    }
+    const workspace = this.config.state.workspaceOrGetWorkspace();
 
     if (!workspace || !project) {
       return html``;
@@ -338,13 +326,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
   }
 
   templateWorkspace(): TemplateResult {
-    const workspace = this.config.state.workspace;
-
-    // Lazy load the workspace.
-    if (!workspace) {
-      this.loadWorkspace();
-    }
-
+    const workspace = this.config.state.workspaceOrGetWorkspace();
     const workspaceCommitHash = (workspace?.branch.commit.hash || '...').slice(
       0,
       5
@@ -394,7 +376,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     } else {
       return html``;
     }
-    const workspace = this.config.state.workspace;
+    const workspace = this.config.state.workspaceOrGetWorkspace();
 
     return html`<div
       class="le__part__overview__icon le__tooltip le__tooltip--bottom"

--- a/src/ts/editor/ui/parts/overview.ts
+++ b/src/ts/editor/ui/parts/overview.ts
@@ -113,7 +113,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handlePublishClick(evt: Event) {
-    const project = this.config.state.project;
+    const project = this.config.state.projectOrGetProject();
     const workspace = this.config.state.workspace;
 
     // Lazy load the workspace.
@@ -226,7 +226,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
   }
 
   templateProjectTitle(): TemplateResult {
-    const project = this.config.state.project;
+    const project = this.config.state.projectOrGetProject();
     const parts: Array<TemplateResult> = [];
     let links = project?.links?.breadcrumbs ?? [];
 
@@ -258,7 +258,7 @@ export class OverviewPart extends BasePart implements UiPartComponent {
   }
 
   templatePublish(): TemplateResult {
-    const project = this.config.state.project;
+    const project = this.config.state.projectOrGetProject();
     const workspace = this.config.state.workspace;
 
     // Lazy load the workspace.

--- a/src/ts/editor/ui/parts/overview.ts
+++ b/src/ts/editor/ui/parts/overview.ts
@@ -116,11 +116,6 @@ export class OverviewPart extends BasePart implements UiPartComponent {
     const project = this.config.state.project;
     const workspace = this.config.state.workspace;
 
-    // Lazy load the project.
-    if (project === undefined) {
-      this.config.state.getProject();
-    }
-
     // Lazy load the workspace.
     if (!workspace) {
       this.loadWorkspace();
@@ -232,12 +227,6 @@ export class OverviewPart extends BasePart implements UiPartComponent {
 
   templateProjectTitle(): TemplateResult {
     const project = this.config.state.project;
-
-    // Lazy load the project.
-    if (project === undefined) {
-      this.config.state.getProject();
-    }
-
     const parts: Array<TemplateResult> = [];
     let links = project?.links?.breadcrumbs ?? [];
 
@@ -271,11 +260,6 @@ export class OverviewPart extends BasePart implements UiPartComponent {
   templatePublish(): TemplateResult {
     const project = this.config.state.project;
     const workspace = this.config.state.workspace;
-
-    // Lazy load the project.
-    if (project === undefined) {
-      this.config.state.getProject();
-    }
 
     // Lazy load the workspace.
     if (!workspace) {

--- a/src/ts/projectType/amagaki/field/document.ts
+++ b/src/ts/projectType/amagaki/field/document.ts
@@ -87,10 +87,7 @@ export class AmagakiDocumentField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
-    this.render();
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(documentFiles: Array<FileData>) {

--- a/src/ts/projectType/amagaki/field/static.ts
+++ b/src/ts/projectType/amagaki/field/static.ts
@@ -85,9 +85,7 @@ export class AmagakiStaticField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(filteredFiles: Array<FileData>) {

--- a/src/ts/projectType/amagaki/field/yaml.ts
+++ b/src/ts/projectType/amagaki/field/yaml.ts
@@ -98,11 +98,7 @@ export class AmagakiYamlField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
-
-    this.render();
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(documentFiles: Array<FileData>) {

--- a/src/ts/projectType/grow/field/document.ts
+++ b/src/ts/projectType/grow/field/document.ts
@@ -87,10 +87,7 @@ export class GrowDocumentField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
-    this.render();
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(documentFiles: Array<FileData>) {

--- a/src/ts/projectType/grow/field/static.ts
+++ b/src/ts/projectType/grow/field/static.ts
@@ -85,9 +85,7 @@ export class GrowStaticField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(filteredFiles: Array<FileData>) {

--- a/src/ts/projectType/grow/field/yaml.ts
+++ b/src/ts/projectType/grow/field/yaml.ts
@@ -98,10 +98,7 @@ export class GrowYamlField extends AutocompleteConstructorField {
     });
 
     // Load the files if not loaded.
-    if (this.globalConfig.state.files === undefined) {
-      this.globalConfig.state.getFiles();
-    }
-    this.render();
+    this.globalConfig.state.filesOrGetFiles();
   }
 
   updateItems(documentFiles: Array<FileData>) {


### PR DESCRIPTION
When data is being retrieved from the api it handles the error and displays a notification, but the next render tries to reload the same api call since the value is still `undefined`.

This change gives a `null` value for data in the state for the values that are loaded without arguments and adds helper functions that trigger the api calls if the value is `undefined` but not if it is `null`. This makes it simpler for the UI to use the state without having to know and handle the `null` state and still allow for lazy loading of the data.

fixes #128