### PR TITLE
feat: Hidden partials and partial priority.

### DIFF
--- a/src/ts/editor/api.ts
+++ b/src/ts/editor/api.ts
@@ -510,8 +510,33 @@ export interface FileData {
 }
 
 export interface PartialData {
+  /**
+   * Partial identifier.
+   *
+   * This is the same value used in the partial definition of partials
+   * in content files.
+   */
   partial: string;
+  /**
+   * Is the partial hidden?
+   *
+   * Partials can opt to not show the partial in the listing of partials.
+   * This is helpful for partials that are part of the design such as
+   * header and footer partials.
+   */
+  isHidden?: boolean;
+  /**
+   * Configuration for how the editor should present the partial in the
+   * editor.
+   */
   editor?: PartialEditorConfig;
+  /**
+   * When displaying lists of paritals the priority will affect the
+   * sort order of the partials.
+   *
+   * Default priority is 1000
+   */
+  priority?: number;
 }
 
 /**

--- a/src/ts/example/exampleApi.ts
+++ b/src/ts/example/exampleApi.ts
@@ -2076,6 +2076,19 @@ export class ExampleAmagakiApi implements AmagakiProjectTypeApi {
               ],
             },
           } as PartialData,
+          hidden: {
+            editor: {
+              label: 'Hidden partial',
+              fields: [
+                {
+                  type: 'text',
+                  key: 'title',
+                  label: 'title',
+                } as TextFieldConfig,
+              ],
+            },
+            isHidden: true,
+          } as PartialData,
         },
         this.options
       );

--- a/src/ts/projectType/generic/field/partials.ts
+++ b/src/ts/projectType/generic/field/partials.ts
@@ -155,15 +155,20 @@ export class GenericPartialsField
       const options = [];
       for (const [partialKey, partial] of Object.entries(this.partials || {})) {
         // Without the editor config there are no fields to add for a partial.
-        if (!partial.editor) {
+        // Also don't show the hidden partials.
+        if (!partial.editor || partial.isHidden) {
           continue;
         }
 
         options.push({
           label: partial.editor.label || partialKey,
           value: partialKey,
+          priority: partial.priority ?? 1000,
         });
       }
+
+      // Sort the options by priority.
+      options.sort((a, b) => a.priority - b.priority);
 
       const selectiveConfig = merge(
         {},


### PR DESCRIPTION
Allows the partial to be hidden from the partial list (ex: when adding a new partial to a page).

Also adds a priority option to be able to give priority to specific partials. For example, making the spacer partial appear first in the list.

Fixes #222