### PR TITLE
fix: Allow delete modal to submit when the form is clean.

### DIFF
--- a/src/ts/editor/ui/parts/menu/site.ts
+++ b/src/ts/editor/ui/parts/menu/site.ts
@@ -192,7 +192,7 @@ export class SitePart extends MenuSectionPart {
           return;
         }
 
-        if (modal.selective.isClean || !modal.selective.isValid) {
+        if (!modal.selective.isValid) {
           modal.stopProcessing();
           return;
         }


### PR DESCRIPTION
Since there are no inputs it will always be clean.